### PR TITLE
Update pom.xml for better Maven 3 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
-            <artifactId>thrift</artifactId>
-            <version>2009-08-26</version>
+            <artifactId>libthrift</artifactId>
+            <version>0.6.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -52,6 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -59,6 +60,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
- Add version numbers for compiler and source plugins
- Switch to the public Thrift distribution
