### PR TITLE
Added text/html mime type

### DIFF
--- a/src/main/resources/META-INF/mime.types
+++ b/src/main/resources/META-INF/mime.types
@@ -1,3 +1,4 @@
+text/html html htm
 application/javascript js
 image/png png
 text/css css


### PR DESCRIPTION
Some systems don't have a mime.types file (_cough_Amazon EC2_cough_) in the Java lib directory and so HTML files will be rendered as application/octet-stream forcing browsers to download the HTML file instead of showing it.

All as per http://docs.oracle.com/javase/6/docs/api/javax/activation/MimetypesFileTypeMap.html

I'm sure more could be added here to be safe, but I just added what I needed for the moment.
