### PR TITLE
Netty 4 Alpha has removed org.jboss from packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.2.3.Final</version>
+            <version>netty-4.0.0.Alpha1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/se/cgbystrom/netty/FlashPolicyHandler.java
+++ b/src/main/java/se/cgbystrom/netty/FlashPolicyHandler.java
@@ -1,14 +1,14 @@
 package se.cgbystrom.netty;
 
-import org.jboss.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelFutureListener;
 
-import org.jboss.netty.handler.codec.frame.FrameDecoder;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.handler.codec.frame.FrameDecoder;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.util.CharsetUtil;
 
 /**
  * A Flash policy file handler

--- a/src/main/java/se/cgbystrom/netty/http/BandwidthMeterHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/BandwidthMeterHandler.java
@@ -1,13 +1,13 @@
 package se.cgbystrom.netty.http;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.ChannelEvent;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelHandler;
-import org.jboss.netty.util.Timeout;
-import org.jboss.netty.util.Timer;
-import org.jboss.netty.util.TimerTask;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.channel.ChannelEvent;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelHandler;
+import io.netty.util.Timeout;
+import io.netty.util.Timer;
+import io.netty.util.TimerTask;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -81,7 +81,7 @@ public class BandwidthMeterHandler extends SimpleChannelHandler {
     /**
      * Constructs a new instance without time based statistics.
      * {@link #getBytesSentPerSecond()} and {@link #getBytesReceivedPerSecond()} will not work.
-     * For these statistics, instantiate with {@link #BandwidthMeterHandler(org.jboss.netty.util.Timer)} instead.
+     * For these statistics, instantiate with {@link #BandwidthMeterHandler(io.netty.util.Timer)} instead.
      */
     public BandwidthMeterHandler() {
     }

--- a/src/main/java/se/cgbystrom/netty/http/CachableHttpResponse.java
+++ b/src/main/java/se/cgbystrom/netty/http/CachableHttpResponse.java
@@ -1,8 +1,8 @@
 package se.cgbystrom.netty.http;
 
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 
 public class CachableHttpResponse extends DefaultHttpResponse {
     private String requestUri;

--- a/src/main/java/se/cgbystrom/netty/http/CacheHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/CacheHandler.java
@@ -1,21 +1,21 @@
 package se.cgbystrom.netty.http;
 
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.*;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpMessage;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.channel.*;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 public class CacheHandler extends SimpleChannelHandler {
     private static Pattern maxAgePattern = Pattern.compile("max-age=\\d+");

--- a/src/main/java/se/cgbystrom/netty/http/FileServerHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/FileServerHandler.java
@@ -1,24 +1,24 @@
 package se.cgbystrom.netty.http;
 
-import static org.jboss.netty.handler.codec.http.HttpHeaders.*;
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.*;
-import static org.jboss.netty.handler.codec.http.HttpMethod.*;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.*;
-import static org.jboss.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.handler.codec.http.HttpHeaders.*;
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpMethod.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
 
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.*;
-import org.jboss.netty.handler.codec.frame.TooLongFrameException;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.QueryStringDecoder;
-import org.jboss.netty.handler.ssl.SslHandler;
-import org.jboss.netty.handler.stream.ChunkedFile;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.channel.*;
+import io.netty.handler.codec.frame.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedFile;
+import io.netty.util.CharsetUtil;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.*;

--- a/src/main/java/se/cgbystrom/netty/http/SimpleResponseHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/SimpleResponseHandler.java
@@ -1,18 +1,18 @@
 package se.cgbystrom.netty.http;
 
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelUpstreamHandler;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.nio.charset.Charset;
 
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 public class SimpleResponseHandler extends SimpleChannelUpstreamHandler {
     private String text;

--- a/src/main/java/se/cgbystrom/netty/http/router/RouterHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/router/RouterHandler.java
@@ -1,7 +1,7 @@
 package se.cgbystrom.netty.http.router;
 
-import org.jboss.netty.channel.*;
-import org.jboss.netty.handler.codec.http.HttpRequest;
+import io.netty.channel.*;
+import io.netty.handler.codec.http.HttpRequest;
 import se.cgbystrom.netty.http.SimpleResponseHandler;
 
 import java.util.LinkedHashMap;

--- a/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketCallback.java
+++ b/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketCallback.java
@@ -1,6 +1,7 @@
 package se.cgbystrom.netty.http.websocket;
 
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+
 
 /**
  * Callbacks for the {@link WebSocketClient}.

--- a/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClient.java
+++ b/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClient.java
@@ -1,7 +1,7 @@
 package se.cgbystrom.netty.http.websocket;
 
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
+import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 
 /**
  * A WebSocket client

--- a/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClientFactory.java
+++ b/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClientFactory.java
@@ -1,12 +1,12 @@
 package se.cgbystrom.netty.http.websocket;
 
-import org.jboss.netty.bootstrap.ClientBootstrap;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.Channels;
-import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
-import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
-import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.bootstrap.ClientBootstrap;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPipelineFactory;
+import io.netty.channel.Channels;
+import io.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponseDecoder;
 
 import java.net.URI;
 import java.util.concurrent.Executors;

--- a/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClientHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/websocket/WebSocketClientHandler.java
@@ -1,26 +1,25 @@
 package se.cgbystrom.netty.http.websocket;
 
-import org.jboss.netty.bootstrap.ClientBootstrap;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelStateEvent;
-import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.jboss.netty.handler.codec.http.websocket.DefaultWebSocketFrame;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameDecoder;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameEncoder;
-import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
-import org.jboss.netty.handler.codec.http.HttpHeaders.Values;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.bootstrap.ClientBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelStateEvent;
+import io.netty.channel.ExceptionEvent;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelUpstreamHandler;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
+import io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder;
+import io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.util.CharsetUtil;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -58,7 +57,7 @@ public class WebSocketClientHandler extends SimpleChannelUpstreamHandler impleme
         request.addHeader(Names.ORIGIN, "http://" + url.getHost());
 
         e.getChannel().write(request);
-        ctx.getPipeline().replace("encoder", "ws-encoder", new WebSocketFrameEncoder());
+        ctx.getPipeline().replace("encoder", "ws-encoder", new WebSocket13FrameEncoder(true));
         channel = e.getChannel();
     }
 
@@ -83,7 +82,7 @@ public class WebSocketClientHandler extends SimpleChannelUpstreamHandler impleme
             }
             
             handshakeCompleted = true;
-            ctx.getPipeline().replace("decoder", "ws-decoder", new WebSocketFrameDecoder());
+            ctx.getPipeline().replace("decoder", "ws-decoder", new WebSocket13FrameDecoder(true,false));
             callback.onConnect(this);
             return;
         }
@@ -93,7 +92,7 @@ public class WebSocketClientHandler extends SimpleChannelUpstreamHandler impleme
             throw new WebSocketException("Unexpected HttpResponse (status=" + response.getStatus() + ", content=" + response.getContent().toString(CharsetUtil.UTF_8) + ")");
         }
 
-        DefaultWebSocketFrame frame = (DefaultWebSocketFrame)e.getMessage();
+        WebSocketFrame frame = (WebSocketFrame)e.getMessage();
         callback.onMessage(this, frame);
     }
 

--- a/src/main/java/se/cgbystrom/netty/thrift/TNettyChannelBuffer.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/TNettyChannelBuffer.java
@@ -2,7 +2,7 @@ package se.cgbystrom.netty.thrift;
 
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ChannelBuffer;
 
 /**
  * Thrift transport based on JBoss Netty's ChannelBuffers

--- a/src/main/java/se/cgbystrom/netty/thrift/TNettyTransport.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/TNettyTransport.java
@@ -5,9 +5,9 @@ import java.util.concurrent.BlockingQueue;
 
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.Channel;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.channel.Channel;
 
 /**
  * Bridge between Netty and the client-side TTransport.

--- a/src/main/java/se/cgbystrom/netty/thrift/ThriftClientHandler.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/ThriftClientHandler.java
@@ -3,11 +3,11 @@ package se.cgbystrom.netty.thrift;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelHandler;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 
 /**
  * A client-side ChannelHandler for the Thrift protocol.

--- a/src/main/java/se/cgbystrom/netty/thrift/ThriftPipelineFactory.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/ThriftPipelineFactory.java
@@ -1,12 +1,12 @@
 package se.cgbystrom.netty.thrift;
 
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.handler.codec.frame.LengthFieldBasedFrameDecoder;
-import org.jboss.netty.handler.codec.frame.LengthFieldPrepender;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPipelineFactory;
+import io.netty.handler.codec.frame.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.frame.LengthFieldPrepender;
 
-import static org.jboss.netty.channel.Channels.pipeline;
+import static io.netty.channel.Channels.pipeline;
 
 /**
  * Pipeline factory for Thrift servers and clients

--- a/src/main/java/se/cgbystrom/netty/thrift/ThriftServerHandler.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/ThriftServerHandler.java
@@ -4,19 +4,19 @@ import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpVersion;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelUpstreamHandler;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 
 /**
  * Handler for Thrift RPC processors

--- a/src/main/java/se/cgbystrom/netty/thrift/http/HttpEncoder.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/http/HttpEncoder.java
@@ -1,14 +1,14 @@
 package se.cgbystrom.netty.thrift.http;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.jboss.netty.handler.codec.oneone.OneToOneEncoder;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.oneone.OneToOneEncoder;
 
 /**
  * Client-side Http Encoder.

--- a/src/main/java/se/cgbystrom/netty/thrift/http/ThriftHttpClientPipelineFactory.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/http/ThriftHttpClientPipelineFactory.java
@@ -1,13 +1,13 @@
 package se.cgbystrom.netty.thrift.http;
 
-import static org.jboss.netty.channel.Channels.pipeline;
+import static io.netty.channel.Channels.pipeline;
 
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
-import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
-import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPipelineFactory;
+import io.netty.handler.codec.http.HttpChunkAggregator;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponseDecoder;
 
 import se.cgbystrom.netty.thrift.ThriftHandler;
 

--- a/src/main/java/se/cgbystrom/netty/thrift/http/ThriftHttpServerPipelineFactory.java
+++ b/src/main/java/se/cgbystrom/netty/thrift/http/ThriftHttpServerPipelineFactory.java
@@ -1,13 +1,13 @@
 package se.cgbystrom.netty.thrift.http;
 
-import static org.jboss.netty.channel.Channels.pipeline;
+import static io.netty.channel.Channels.pipeline;
 
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
-import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
-import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPipelineFactory;
+import io.netty.handler.codec.http.HttpChunkAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
 
 import se.cgbystrom.netty.thrift.ThriftHandler;
 

--- a/src/test/java/se/cgbystrom/netty/HttpTest.java
+++ b/src/test/java/se/cgbystrom/netty/HttpTest.java
@@ -5,20 +5,22 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-import org.jboss.netty.bootstrap.ServerBootstrap;
-import org.jboss.netty.channel.ChannelException;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.Channels;
-import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
-import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
-import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
-import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
-import org.jboss.netty.handler.codec.http.websocket.DefaultWebSocketFrame;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
-import org.jboss.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelException;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPipelineFactory;
+import io.netty.channel.Channels;
+import io.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import io.netty.handler.codec.http.HttpChunkAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+
+import io.netty.handler.stream.ChunkedWriteHandler;
 import org.junit.Test;
+
 import se.cgbystrom.netty.http.BandwidthMeterHandler;
 import se.cgbystrom.netty.http.CacheHandler;
 import se.cgbystrom.netty.http.FileServerHandler;
@@ -135,7 +137,7 @@ public class HttpTest {
         Thread.sleep(1000);
 
         assertTrue(callback.connected);
-        assertEquals(TestClient.TEST_MESSAGE.toUpperCase(), callback.messageReceived);
+        assertEquals(TestClient.TEST_MESSAGE, callback.messageReceived);
         client.disconnect();
         Thread.sleep(1000);
 
@@ -231,7 +233,7 @@ public class HttpTest {
         public void onConnect(WebSocketClient client) {
             System.out.println("WebSocket connected!");
             connected = true;
-            client.send(new DefaultWebSocketFrame(TEST_MESSAGE));
+            client.send(new TextWebSocketFrame(TEST_MESSAGE));
         }
 
         public void onDisconnect(WebSocketClient client) {
@@ -240,8 +242,8 @@ public class HttpTest {
         }
 
         public void onMessage(WebSocketClient client, WebSocketFrame frame) {
-            System.out.println("Message:" + frame.getTextData());
-            messageReceived = frame.getTextData();
+            System.out.println("Message:" + ((TextWebSocketFrame)frame).getText());
+            messageReceived = ((TextWebSocketFrame)frame).getText();
         }
 
         public void onError(Throwable t) {

--- a/src/test/java/se/cgbystrom/netty/WebSocketServerHandler.java
+++ b/src/test/java/se/cgbystrom/netty/WebSocketServerHandler.java
@@ -17,34 +17,34 @@ package se.cgbystrom.netty;
  * under the License.
  */
 
-import static org.jboss.netty.handler.codec.http.HttpHeaders.*;
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.*;
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Values.*;
-import static org.jboss.netty.handler.codec.http.HttpMethod.*;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.*;
-import static org.jboss.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.handler.codec.http.HttpHeaders.*;
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaders.Values.*;
+import static io.netty.handler.codec.http.HttpMethod.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
-import org.jboss.netty.handler.codec.http.HttpHeaders.Values;
-import org.jboss.netty.handler.codec.http.websocket.DefaultWebSocketFrame;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameDecoder;
-import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameEncoder;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ChannelBuffers;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ExceptionEvent;
+import io.netty.channel.MessageEvent;
+import io.netty.channel.SimpleChannelUpstreamHandler;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder;
+import io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.util.CharsetUtil;
 
 /**
  * A modified version of Trustin Lee's original WebSocket server example
@@ -97,11 +97,11 @@ public class WebSocketServerHandler extends SimpleChannelUpstreamHandler {
             // Upgrade the connection and send the handshake response.
             ChannelPipeline p = ctx.getChannel().getPipeline();
             p.remove("aggregator");
-            p.replace("decoder", "wsdecoder", new WebSocketFrameDecoder());
+            p.replace("decoder", "wsdecoder", new WebSocket13FrameDecoder(true,false));
 
             ctx.getChannel().write(res);
-            p.replace("encoder", "wsencoder", new WebSocketFrameEncoder());
-            ctx.getChannel().write(new DefaultWebSocketFrame("Welcome!"));
+            p.replace("encoder", "wsencoder", new WebSocket13FrameEncoder(true));
+            ctx.getChannel().write(new TextWebSocketFrame("Welcome!"));
             return;
         }
 
@@ -113,7 +113,7 @@ public class WebSocketServerHandler extends SimpleChannelUpstreamHandler {
     private void handleWebSocketFrame(ChannelHandlerContext ctx, WebSocketFrame frame) {
         // Send the uppercased string back.
         ctx.getChannel().write(
-                new DefaultWebSocketFrame(frame.getTextData().toUpperCase()));
+                new TextWebSocketFrame(frame.getBinaryData()));
     }
 
     private void sendHttpResponse(ChannelHandlerContext ctx, HttpRequest req, HttpResponse res) {


### PR DESCRIPTION
Netty 4 has removed org.jboss from all the packages, plus it has included the websocket handshakers and client from Netty Tools (with some minor modifications). The changes should be backward compatible, however, some of the netty-tools classes are now obsolete (and may not work with Netty 4's decoders) because they are included in netty directly. Additionally, I updated the pom for the Alpha snapshot dependency. I'm not sure if that library exists in external or jboss repos, as I just compiled and installed the Netty libs into my local maven repo directly. I was able to basically replace all of my websocket handling with the Netty 4 versions and use netty-tools for just the RouterHandler.
