### PR TITLE
Netty 3.4.0 bump and RouterHandler behaviour change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cgbystrom</groupId>
     <artifactId>netty-tools</artifactId>
-    <version>1.2.8-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>netty-tools</name>
     <packaging>jar</packaging>
     <description>
@@ -44,9 +44,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.netty</groupId>
+            <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.2.3.Final</version>
+            <version>3.3.0.Final</version>
+            <!--<packaging>bundle</packaging>-->
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
RouterHandler has been given a new construction which allows for the 404 behavior to be configured, default is still to handle by modifying the pipeline. If specified the RouterHandler will now ignore handling routes which it can not resolve
