### PR TITLE
Adding option for a default handler for RouterHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings
+target

--- a/src/main/java/se/cgbystrom/netty/http/CacheEntry.java
+++ b/src/main/java/se/cgbystrom/netty/http/CacheEntry.java
@@ -1,0 +1,21 @@
+package se.cgbystrom.netty.http;
+
+import org.jboss.netty.handler.codec.http.HttpMessage;
+
+public class CacheEntry {
+    private HttpMessage content;
+    private long expires;
+
+    public CacheEntry(HttpMessage content, long expires) {
+        this.content = content;
+        this.expires = expires;
+    }
+    
+    public HttpMessage getContent() {
+		return content;
+	}
+    
+    public long getExpires() {
+		return expires;
+	}
+}

--- a/src/main/java/se/cgbystrom/netty/http/CacheHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/CacheHandler.java
@@ -28,8 +28,8 @@ public class CacheHandler extends SimpleChannelHandler {
             HttpRequest request = (HttpRequest)((MessageEvent)e).getMessage();
 
             CacheEntry ce = cache.get(request.getUri());
-            if (ce != null && ce.expires > System.currentTimeMillis()) {
-                ChannelFuture f = e.getChannel().write(ce.content);
+            if (ce != null && ce.getExpires() > System.currentTimeMillis()) {
+                ChannelFuture f = e.getChannel().write(ce.getContent());
                 f.addListener(ChannelFutureListener.CLOSE);
                 if (!HttpHeaders.isKeepAlive(request)) {
                     f.addListener(ChannelFutureListener.CLOSE);
@@ -75,15 +75,5 @@ public class CacheHandler extends SimpleChannelHandler {
 
         // Close the connection as soon as the error message is sent.
         ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
-    }
-
-    private static class CacheEntry {
-        public HttpMessage content;
-        public long expires;
-
-        private CacheEntry(HttpMessage content, long expires) {
-            this.content = content;
-            this.expires = expires;
-        }
     }
 }

--- a/src/main/java/se/cgbystrom/netty/http/CachedChannelBuffer.java
+++ b/src/main/java/se/cgbystrom/netty/http/CachedChannelBuffer.java
@@ -1,0 +1,21 @@
+package se.cgbystrom.netty.http;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+public class CachedChannelBuffer {
+	private ChannelBuffer channelBuffer;
+	private long expires;
+	
+	public CachedChannelBuffer(ChannelBuffer channelBuffer, long expires) {
+		this.channelBuffer = channelBuffer;
+		this.expires = expires;
+	}
+	
+	public ChannelBuffer getChannelBuffer() {
+		return channelBuffer;
+	}
+	
+	public long getExpires() {
+		return expires;
+	}
+}

--- a/src/main/java/se/cgbystrom/netty/http/FileServerHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/FileServerHandler.java
@@ -65,6 +65,14 @@ public class FileServerHandler extends SimpleChannelUpstreamHandler {
         this.stripFromUri = stripFromUri;
     }
 
+    public MimetypesFileTypeMap getFileTypeMap() {
+		return fileTypeMap;
+	}
+    
+    public int getCacheMaxAge() {
+		return cacheMaxAge;
+	}
+    
     @Override
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
         HttpRequest request = (HttpRequest) e.getMessage();
@@ -107,9 +115,9 @@ public class FileServerHandler extends SimpleChannelUpstreamHandler {
             // Close the connection when the whole content is written out.
             writeFuture.addListener(ChannelFutureListener.CLOSE);
         }
-    }
+    } 
 
-    private ChannelBuffer getFileContent(String path) {
+    protected ChannelBuffer getFileContent(String path) {
         InputStream is;
         try {
             if (fromClasspath) {
@@ -158,7 +166,7 @@ public class FileServerHandler extends SimpleChannelUpstreamHandler {
         }
     }
 
-    private String sanitizeUri(String uri) throws URISyntaxException {
+    protected String sanitizeUri(String uri) throws URISyntaxException {
         // Decode the path.
         try {
             uri = URLDecoder.decode(uri, "UTF-8");
@@ -191,7 +199,7 @@ public class FileServerHandler extends SimpleChannelUpstreamHandler {
         return uri;
     }
 
-    private void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+    protected void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, status);
         response.setHeader(CONTENT_TYPE, "text/plain; charset=UTF-8");
         response.setContent(ChannelBuffers.copiedBuffer(

--- a/src/main/java/se/cgbystrom/netty/http/router/RouterHandler.java
+++ b/src/main/java/se/cgbystrom/netty/http/router/RouterHandler.java
@@ -3,6 +3,7 @@ package se.cgbystrom.netty.http.router;
 import org.jboss.netty.channel.*;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import se.cgbystrom.netty.http.SimpleResponseHandler;
+import se.cgbystrom.netty.http.router.Matcher;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -14,15 +15,25 @@ public class RouterHandler extends SimpleChannelUpstreamHandler {
     private static final String ENDS_WITH = "endsWith:";
     private static final String EQUALS = "equals:";
     private static final ChannelHandler HANDLER_404 = new SimpleResponseHandler("Not found", 404);
+    private ChannelHandler defaultHandler;;
+    
     private boolean handleNotFound;
 
+    public RouterHandler(LinkedHashMap<String, ChannelHandler> routes, boolean handleNotFound, ChannelHandler defaultHandler) throws Exception {
+        this.handleNotFound = handleNotFound;
+        this.defaultHandler = defaultHandler;
+        setupRoutes(routes);
+    }
+    
     public RouterHandler(LinkedHashMap<String, ChannelHandler> routes, boolean handleNotFound) throws Exception {
         this.handleNotFound = handleNotFound;
+        this.defaultHandler = null;
         setupRoutes(routes);
     }
 
     public RouterHandler(LinkedHashMap<String, ChannelHandler> routes) throws Exception {
         this.handleNotFound = true;
+        this.defaultHandler = null;
         setupRoutes(routes);
     }
 
@@ -35,29 +46,35 @@ public class RouterHandler extends SimpleChannelUpstreamHandler {
             boolean matchFound = false;
             for (Map.Entry<Matcher, ChannelHandler> m : routes.entrySet()) {
                 if (m.getKey().match(uri)) {
-                    ChannelPipeline p = ctx.getPipeline();
-                    synchronized (p) {
-                        if (p.get("route-generated") == null) {
-                            p.addLast("route-generated", m.getValue());
-                        } else {
-                            p.replace("route-generated", "route-generated", m.getValue());
-                        }
-                    }
+                    addOrReplaceHandler(ctx.getPipeline(), m.getValue(), "route-generated");
                     matchFound = true;
                     break;
                 }
             }
 
+            if (!matchFound && !handleNotFound && defaultHandler != null) {
+            	addOrReplaceHandler(ctx.getPipeline(), defaultHandler, "default-handler");
+            }
             /*
             If the route can't be found and we are supposed to handle not found URLs we append a 404 handler
              */
             if (!matchFound && handleNotFound) {
-                ctx.getPipeline().addLast("404-handler", HANDLER_404);
+            	addOrReplaceHandler(ctx.getPipeline(), HANDLER_404, "404-handler");
             }
         }
 
         super.handleUpstream(ctx, e);
     }
+
+	private void addOrReplaceHandler(ChannelPipeline pipeline, ChannelHandler channelHandler, String handleName) {
+		synchronized (pipeline) {
+		    if (pipeline.get(handleName) == null) {
+		    	pipeline.addLast(handleName, channelHandler);
+		    } else {
+		    	pipeline.replace(handleName, handleName, channelHandler);
+		    }
+		}
+	}
 
     private class StartsWithMatcher implements Matcher {
         private String route;


### PR DESCRIPTION
When I am developing a web app, I would usually like the main parts of the application to be loaded as-is. Except for some special circumstances where I would like specific routing (where I would plug in my back-end, etc.) 

Adding an option to add a defaultHandler to the RouterHandler. If a defaultHandler is specifies, and no router match is found, it will attempt to handle any other calls via the defaultHandler. 
